### PR TITLE
Update autocomplete.js

### DIFF
--- a/autocomplete.js
+++ b/autocomplete.js
@@ -614,7 +614,7 @@ class Autocomplete {
       // Prevent input otherwise it might trigger autocomplete due to value change
       this._preventInput = true;
       this._searchInput.value = item.label;
-      this._config.onSelectItem(item);
+      this._config.onSelectItem(item, this._searchInput);
       this.hideSuggestions();
       this._preventInput = false;
     });


### PR DESCRIPTION
Passing the search element when item selected. This is needed to use the item value. Like here:
`onSelectItem: (item, input) => {
        input.dataset.value = item.value; //to set value to dataset
        input.previousElementSibling?.setAttribute('value', item.value); //to set value to input[type=hidden]
}`