### PR TITLE
Fix sorting when value is integer

### DIFF
--- a/autocomplete.js
+++ b/autocomplete.js
@@ -1105,7 +1105,7 @@ class Autocomplete {
 
       // Make sure we have a label
       if (item.label) {
-        this._items[item.value] = item;
+        this._items[item.label] = item;
       }
     }
   }


### PR DESCRIPTION
When an integer value was set via "valueField", the associative array "_items" used the value of "valueField" as key and the array was incorrectly sorted by "valueField" With this pull request it should maintain the correct ordering.