### PR TITLE
allow params.related to be an array of form field IDs as well as curr…

### DIFF
--- a/autocomplete.js
+++ b/autocomplete.js
@@ -80,7 +80,7 @@
  * @property {String} datalist The id of the source datalist
  * @property {String} server Endpoint for data provider
  * @property {String} serverMethod HTTP request method for data provider, default is GET
- * @property {String|Object} serverParams Parameters to pass along to the server. You can specify a "related" key with the id of a related field.
+ * @property {String|Object} serverParams Parameters to pass along to the server.  You can specify a "related" key with (a) the id of a related field or (b) an array of related field ids.
  * @property {String} serverDataKey By default: data
  * @property {Object} fetchOptions Any other fetch options (https://developer.mozilla.org/en-US/docs/Web/API/fetch#syntax)
  * @property {Boolean} liveServer Should the endpoint be called each time on input
@@ -1256,20 +1256,24 @@ class Autocomplete {
     if (this._config.noCache) {
       params.t = Date.now();
     }
-    // We have a related field
+      
+     // We have a related field or an array of related fields
     if (params.related) {
-      /**
-       * @type {HTMLInputElement}
-       */
-      //@ts-ignore
-      const input = document.getElementById(params.related);
-      if (input) {
-        params.related = input.value;
-        const inputName = input.getAttribute("name");
-        if (inputName) {
-          params[inputName] = input.value;
+      // Check if params.related is an array
+      const relatedItems = Array.isArray(params.related) ? params.related : [params.related];
+    
+      relatedItems.forEach((related) => {
+        const input = document.getElementById(related);
+        if (input) {
+          const inputValue = input.value;
+          const inputName = input.getAttribute("name");
+    
+          // Update params with the input value
+          if (inputName) {
+            params[inputName] = inputValue;
+          }
         }
-      }
+      });
     }
 
     const urlParams = new URLSearchParams(params);


### PR DESCRIPTION
…ent behaviour of string

Sometimes more than one form field is needed for the backend auto-completion search.