### PR TITLE
Improve NPM and TypeScript support #62

### DIFF
--- a/autocomplete.js
+++ b/autocomplete.js
@@ -338,7 +338,7 @@ class Autocomplete {
   /**
    * Attach to all elements matched by the selector
    * @param {string} selector
-   * @param {Config|Object} config
+   * @param {Partial<Config>} config
    */
   static init(selector = "input.autocomplete", config = {}) {
     /**

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.1.35",
   "description": "Autocomplete for Bootstrap 5 (and 4!)",
   "main": "autocomplete",
+  "types": "types/autocomplete.d.ts",
   "scripts": {
     "test": "ava",
     "build": "esbuild --mangle-props=^_ --bundle --minify --format=esm --sourcemap autocomplete.js --outfile=autocomplete.min.js",

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,30 @@ import Autocomplete from "./autocomplete.js";
 Autocomplete.init();
 ```
 
+When using CDN version from TypeScript file, for example:
+
+```ts
+import Autocomplete, { type Config } from "https://cdn.jsdelivr.net/gh/lekoala/bootstrap5-autocomplete@master/autocomplete.js";
+
+const options: Partial<Config> = {
+    //...
+}
+Autocomplete.init('#myInput', options);
+```
+
+Path mapping in `tsconfig.json` is required in order to load types from local NPM package:
+
+```json
+{
+    "compilerOptions": {
+        //...
+        "paths": {
+            "https://cdn.jsdelivr.net/gh/lekoala/bootstrap5-autocomplete@master/autocomplete.js": [ "./node_modules/bootstrap5-autocomplete/types/autocomplete.d.ts" ]
+        }
+    }
+}
+```
+
 ## Server side support
 
 You can also use options provided by the server. This script expects a JSON response with the following structure:


### PR DESCRIPTION
As described in the issue "Improve NPM and TypeScript support" #62:

Based on a discussion from closed issue https://github.com/lekoala/bootstrap5-autocomplete/issues/26, there are couple of small things that can be improved when using this library as an NPM package and when using it TypeScript (npm or CDN):

1. types property in the package.json can be added ("types": "types/autocomplete.d.ts")
2. TypeScript type Partial<Config> can be used instead of Config | Object
3. ReadMe can be clearer/improved:
    a. When using NPM package, correct import is import Autosuggest from "bootstrap5-autocomplete"
    b. Example on how to use TypeScript types within client application, when loading library from CDN can be added. Modification in client-app tsconfig.json:
    ```json
    "paths": {
        "https://cdn.jsdelivr.net/gh/lekoala/bootstrap5-autocomplete@master/autocomplete.js": [ "./node_modules/bootstrap5-autocomplete/types/autocomplete.d.ts" ]
    }
    ```