### PR TITLE
Further Improve TypeScript Definitions

### DIFF
--- a/autocomplete.js
+++ b/autocomplete.js
@@ -82,7 +82,7 @@
  * @property {String} serverMethod HTTP request method for data provider, default is GET
  * @property {String|Object} serverParams Parameters to pass along to the server.  You can specify a "related" key with (a) the id of a related field or (b) an array of related field ids.
  * @property {String} serverDataKey By default: data
- * @property {Object} fetchOptions Any other fetch options (https://developer.mozilla.org/en-US/docs/Web/API/fetch#syntax)
+ * @property {RequestInit} fetchOptions Any other fetch options (https://developer.mozilla.org/en-US/docs/Web/API/fetch#syntax)
  * @property {Boolean} liveServer Should the endpoint be called each time on input
  * @property {Boolean} noCache Prevent caching by appending a timestamp
  * @property {Number} debounceTime Debounce time for live server
@@ -167,6 +167,9 @@ const SHOW_CLASS = "show";
 const NEXT = "next";
 const PREV = "prev";
 
+/**
+ * @type WeakMap<HTMLElement, Autocomplete>
+ */
 const INSTANCE_MAP = new WeakMap();
 let counter = 0;
 let activeCounter = 0;
@@ -286,7 +289,7 @@ function nested(str, obj = "window") {
 class Autocomplete {
   /**
    * @param {HTMLInputElement} el
-   * @param {Config|Object} config
+   * @param {Partial<Config>} config
    */
   constructor(el, config = {}) {
     if (!(el instanceof HTMLElement)) {
@@ -352,6 +355,7 @@ class Autocomplete {
 
   /**
    * @param {HTMLInputElement} el
+   * @returns {Autocomplete | null}
    */
   static getInstance(el) {
     return INSTANCE_MAP.has(el) ? INSTANCE_MAP.get(el) : null;
@@ -359,7 +363,8 @@ class Autocomplete {
 
   /**
    * @param {HTMLInputElement} el
-   * @param {Object} config
+   * @param {Partial<Config>} config
+   * @returns {Autocomplete}
    */
   static getOrCreateInstance(el, config = {}) {
     return this.getInstance(el) || new this(el, config);
@@ -416,7 +421,7 @@ class Autocomplete {
   };
 
   /**
-   * @param {Config|Object} config
+   * @param {Partial<Config>} config
    */
   _configure(config = {}) {
     this._config = Object.assign({}, DEFAULTS);

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,12 @@ import Autocomplete from "./autocomplete.js";
 Autocomplete.init();
 ```
 
+When using NPM package:
+```js
+import Autocomplete from "bootstrap5-autocomplete";
+Autocomplete.init();
+```
+
 When using CDN version from TypeScript file, for example:
 
 ```ts
@@ -32,7 +38,7 @@ Path mapping in `tsconfig.json` is required in order to load types from local NP
     "compilerOptions": {
         //...
         "paths": {
-            "https://cdn.jsdelivr.net/gh/lekoala/bootstrap5-autocomplete@master/autocomplete.js": [ "./node_modules/bootstrap5-autocomplete/types/autocomplete.d.ts" ]
+            "https://cdn.jsdelivr.net/gh/lekoala/bootstrap5-autocomplete@master/autocomplete.js": [ "./node_modules/bootstrap5-autocomplete" ]
         }
     }
 }

--- a/types/autocomplete.d.ts
+++ b/types/autocomplete.d.ts
@@ -133,7 +133,7 @@ export type Config = {
     /**
      * Any other fetch options (https://developer.mozilla.org/en-US/docs/Web/API/fetch#syntax)
      */
-    fetchOptions: any;
+    fetchOptions: RequestInit;
     /**
      * Should the endpoint be called each time on input
      */
@@ -192,18 +192,20 @@ declare class Autocomplete {
     static init(selector?: string, config?: Partial<Config>): void;
     /**
      * @param {HTMLInputElement} el
+     * @returns {Autocomplete | null}
      */
-    static getInstance(el: HTMLInputElement): any;
+    static getInstance(el: HTMLInputElement): Autocomplete | null;
     /**
      * @param {HTMLInputElement} el
-     * @param {Object} config
+     * @param {Partial<Config>} config
+     * @returns {Autocomplete}
      */
-    static getOrCreateInstance(el: HTMLInputElement, config?: any): any;
+    static getOrCreateInstance(el: HTMLInputElement, config?: Partial<Config>): Autocomplete;
     /**
      * @param {HTMLInputElement} el
-     * @param {Config|Object} config
+     * @param {Partial<Config>} config
      */
-    constructor(el: HTMLInputElement, config?: Config | any);
+    constructor(el: HTMLInputElement, config?: Partial<Config>);
     _searchInput: HTMLInputElement;
     _isMouse: boolean;
     _preventInput: boolean;
@@ -219,9 +221,9 @@ declare class Autocomplete {
     handleEvent: (event: Event) => void;
     _timer: number;
     /**
-     * @param {Config|Object} config
+     * @param {Partial<Config>} config
      */
-    _configure(config?: Config | any): void;
+    _configure(config?: Partial<Config>): void;
     _config: any;
     _configureSearchInput(): void;
     _hiddenInput: HTMLInputElement;


### PR DESCRIPTION
Improve TypeScript definitions for: `fetchOptions`, `INSTANCE_MAP`, `constructor`, `getInstance`, `getOrCreateInstance` and `_configure`.