### PR TITLE
Make _ShowSuggestions work in web components

### DIFF
--- a/autocomplete.js
+++ b/autocomplete.js
@@ -959,11 +959,31 @@ class Autocomplete {
   }
 
   /**
+   * Get the active element, drilling into shadowRoot if necessary.
+   * @link https://www.abeautifulsite.net/posts/finding-the-active-element-in-a-shadow-root/
+   * @param {Document | ShadowRoot} root
+   * @returns {Element}
+   */
+  _getActiveElement(root = document) {
+    const activeEl = root.activeElement;
+
+    if (!activeEl) {
+      return null;
+    }
+
+    if (activeEl.shadowRoot) {
+      return this._getActiveElement(activeEl.shadowRoot);
+    } else {
+      return activeEl;
+    }
+  }
+
+  /**
    * Show drop menu with suggestions
    */
   _showSuggestions() {
     // It's not focused anymore
-    if (document.activeElement != this._searchInput) {
+    if (this._getActiveElement() != this._searchInput) {
       return;
     }
     const lookup = normalize(this._searchInput.value);


### PR DESCRIPTION
The package can mostly work inside a web component as long as you call getOrCreateInstance() and pass it the elements directly rather than passing selectors to init().

However, when it attempts to show the suggestions you get nothing because activeElement only gives you the active component, not the individual element within it.  So use a little trick found on the interwebs to drill recursively into the shadow DOM if necessary, but it starts from document.activeElement so if you have only light DOM, it does the same thing it always did.